### PR TITLE
Adding ingress and secret

### DIFF
--- a/template/12.0/ce/templates/seafile-ingress.yaml
+++ b/template/12.0/ce/templates/seafile-ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.seafile.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+{{- with .Values.seafile.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: seafile-ingress
+spec:
+{{- if .Values.seafile.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.seafile.ingress.ingressClassName }}
+{{- end }}  
+  tls:
+    - hosts:
+        - {{ .Values.seafile.ingress.url }}
+      secretName: seafile-tls
+  rules:
+  - host: {{ .Values.seafile.ingress.url }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: seafile
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+{{- end -}}

--- a/template/12.0/ce/templates/seafile-secret.yaml
+++ b/template/12.0/ce/templates/seafile-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: seafile-secret
+stringData:
+  INIT_SEAFILE_ADMIN_PASSWORD: {{ .Values.seafile.secret.seafileAdminPassword }}
+  INIT_SEAFILE_MYSQL_ROOT_PASSWORD: {{ .Values.seafile.secret.mysqlRootPassword }}
+  JWT_PRIVATE_KEY: {{ .Values.seafile.secret.jwtPrivateKey }}
+  SEAFILE_MYSQL_DB_PASSWORD: {{ .Values.seafile.secret.mysqlDbPassword }}

--- a/template/12.0/ce/templates/seafile-service.yaml
+++ b/template/12.0/ce/templates/seafile-service.yaml
@@ -5,7 +5,10 @@ metadata:
 spec:
   selector:
     app: seafile
-  type: LoadBalancer
+  type: {{ .Values.seafile.service.type }}
+  {{- if .Values.seafile.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.seafile.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - protocol: TCP
       port: 80

--- a/values/12.0/ce.yaml
+++ b/values/12.0/ce.yaml
@@ -7,7 +7,37 @@ seafile:
     seafileDataVolume: 
       hostPath: /opt/seafile-data
       storage: 10Gi
-  
+
+  # The following are the secret used by seafile
+  secret:
+    seafileAdminPassword: CHANGEME!
+    mysqlRootPassword: CHANGEME!
+    #JWT private key can be generated with the command "pwgen -s 40 1"
+    jwtPrivateKey: CHANGEME!
+    mysqlDbPassword: CHANGEME!
+
+  # The following are to configure the ingress
+  ingress:
+      # -- Specify if an ingress resource for seafile should be created or not
+      enabled: false
+      # -- The ingress class that should be used
+      ingressClassName: ""
+      # -- The url to use for the ingress reverse proxy to point at this pms instance
+      url: seafile.server.com
+      # -- Custom annotations to put on the ingress resource
+      # Example :
+      # annotations:
+      #   cert-manager.io/cluster-issuer: "letsencrypt-staging"
+      annotations: {}
+
+
+  # The following are to configure the service type
+  # Only ClusterIP or LoadBalancer are supported
+  service:
+    type: ClusterIP
+    #If you want to define a static IP address
+    #loadBalancerIP: ""
+
   # The following are environments of seafile services
   env:
     # for Seafile server


### PR DESCRIPTION
Hello,

A little pull request to add ingress and secret to the CE helm chart.
Also this PR bring changes in the service : you can now chose between ClusterIP and LoadBalancer.

I made it because in my cluster I use ingress and not the gateway, as specified in the seafile [documentation](https://manual.seafile.com/12.0/setup/k8s_advanced_management/#k8s-gateway-and-https).
A lot of people still use ingress, so it could be a great thing to support it.

Command to try with helm I used :
`helm upgrade --install seafile -f template/12.0/ce/values.yaml -f values/12.0/ce.yaml template/12.0/ce/ --namespace seafile --create-namespace`.
It was tested with a MariaDB instance.

Feel free to ask any question or make any remark.

Regards,