### PR TITLE
fix PVC and volume options

### DIFF
--- a/template/12.0/ce/templates/_helpers.tpl
+++ b/template/12.0/ce/templates/_helpers.tpl
@@ -15,9 +15,9 @@
         (not $config) 
         (eq ($config.disablePVC | default false) false)
     }}
-        true
+        {{- printf "true" }}
     {{- else }}
-        false
+        {{- printf "false" }}
     {{- end }}
 {{- end }}
 

--- a/template/12.0/cluster/templates/_helpers.tpl
+++ b/template/12.0/cluster/templates/_helpers.tpl
@@ -15,9 +15,9 @@
         (not $config) 
         (eq ($config.disablePVC | default false) false)
     }}
-        true
+        {{- printf "true" }}
     {{- else }}
-        false
+        {{- printf "false" }}
     {{- end }}
 {{- end }}
 

--- a/template/12.0/pro/templates/_helpers.tpl
+++ b/template/12.0/pro/templates/_helpers.tpl
@@ -15,9 +15,9 @@
         (not $config) 
         (eq ($config.disablePVC | default false) false)
     }}
-        true
+        {{- printf "true" }}
     {{- else }}
-        false
+        {{- printf "false" }}
     {{- end }}
 {{- end }}
 

--- a/template/13.0/ce/templates/_helpers.tpl
+++ b/template/13.0/ce/templates/_helpers.tpl
@@ -15,9 +15,9 @@
         (not $config) 
         (eq ($config.disablePVC | default false) false)
     }}
-        true
+        {{- printf "true" }}
     {{- else }}
-        false
+        {{- printf "false" }}
     {{- end }}
 {{- end }}
 

--- a/template/13.0/cluster/templates/_helpers.tpl
+++ b/template/13.0/cluster/templates/_helpers.tpl
@@ -15,9 +15,9 @@
         (not $config) 
         (eq ($config.disablePVC | default false) false)
     }}
-        true
+        {{- printf "true" }}
     {{- else }}
-        false
+        {{- printf "false" }}
     {{- end }}
 {{- end }}
 

--- a/template/13.0/pro/templates/_helpers.tpl
+++ b/template/13.0/pro/templates/_helpers.tpl
@@ -15,9 +15,9 @@
         (not $config) 
         (eq ($config.disablePVC | default false) false)
     }}
-        true
+        {{- printf "true" }}
     {{- else }}
-        false
+        {{- printf "false" }}
     {{- end }}
 {{- end }}
 


### PR DESCRIPTION
The condition is always evaluated as false because of the type discrepancies: 

{{- if include "seafile.seafileDataVolume.enabled" . | eq "true" }}