### PR TITLE
Fix: #21 Whitespace Bug in _helpers.tpl Causing PVC to Never Be Created

### DIFF
--- a/template/12.0/ce/templates/_helpers.tpl
+++ b/template/12.0/ce/templates/_helpers.tpl
@@ -14,10 +14,10 @@
     {{- if or 
         (not $config) 
         (eq ($config.disablePVC | default false) false)
-    }}
-        true
-    {{- else }}
-        false
+    -}}
+    true
+    {{- else -}}
+    false
     {{- end }}
 {{- end }}
 

--- a/template/12.0/cluster/templates/_helpers.tpl
+++ b/template/12.0/cluster/templates/_helpers.tpl
@@ -14,10 +14,10 @@
     {{- if or 
         (not $config) 
         (eq ($config.disablePVC | default false) false)
-    }}
-        true
-    {{- else }}
-        false
+    -}}
+    true
+    {{- else -}}
+    false
     {{- end }}
 {{- end }}
 

--- a/template/12.0/pro/templates/_helpers.tpl
+++ b/template/12.0/pro/templates/_helpers.tpl
@@ -14,10 +14,10 @@
     {{- if or 
         (not $config) 
         (eq ($config.disablePVC | default false) false)
-    }}
-        true
-    {{- else }}
-        false
+    -}}
+    true
+    {{- else -}}
+    false
     {{- end }}
 {{- end }}
 

--- a/template/13.0/ce/templates/_helpers.tpl
+++ b/template/13.0/ce/templates/_helpers.tpl
@@ -14,10 +14,10 @@
     {{- if or 
         (not $config) 
         (eq ($config.disablePVC | default false) false)
-    }}
-        true
-    {{- else }}
-        false
+    -}}
+    true
+    {{- else -}}
+    false
     {{- end }}
 {{- end }}
 

--- a/template/13.0/cluster/templates/_helpers.tpl
+++ b/template/13.0/cluster/templates/_helpers.tpl
@@ -14,10 +14,10 @@
     {{- if or 
         (not $config) 
         (eq ($config.disablePVC | default false) false)
-    }}
-        true
-    {{- else }}
-        false
+    -}}
+    true
+    {{- else -}}
+    false
     {{- end }}
 {{- end }}
 

--- a/template/13.0/pro/templates/_helpers.tpl
+++ b/template/13.0/pro/templates/_helpers.tpl
@@ -14,10 +14,10 @@
     {{- if or 
         (not $config) 
         (eq ($config.disablePVC | default false) false)
-    }}
-        true
-    {{- else }}
-        false
+    -}}
+    true
+    {{- else -}}
+    false
     {{- end }}
 {{- end }}
 


### PR DESCRIPTION
# Summary

Fixes a critical bug described in #20 and #21 introduced in #17 where PersistentVolumeClaims were never created due to a whitespace issue in the `seafile.seafileDataVolume.enabled` template helper.

# Problem

The helper in `_helpers.tpl` returns `"        true"` (with leading whitespace) instead of `"true"`, causing the comparison in `seafile-persistentvolumeclaim.yaml` to always fail:

```yaml
{{- if include "seafile.seafileDataVolume.enabled" . | eq "true" }}
```

Since `"        true" != "true"`, the PersistentVolumeClaim is never rendered.

# Solution

Add `-}}` trimming syntax to remove whitespace after the if and else tags:

```yaml
{{- define "seafile.seafileDataVolume.enabled" -}}
    {{- $config := .Values.seafile.configs.seafileDataVolume -}}
    {{- if or
        (not $config)
        (eq ($config.disablePVC | default false) false)
    -}}
    true
    {{- else -}}
    false
    {{- end }}
{{- end }}
```

# Files Changed

- `template/12.0/ce/templates/_helpers.tpl`
- `template/12.0/cluster/templates/_helpers.tpl`
- `template/12.0/pro/templates/_helpers.tpl`
- `template/13.0/ce/templates/_helpers.tpl`
- `template/13.0/cluster/templates/_helpers.tpl`
- `template/13.0/pro/templates/_helpers.tpl`

# Verification

Tested with helm template using various configurations:

## Test Case 1: disablePVC field absent
Expected: PVC created with default 10Gi storage ✅

```bash
helm template seafile template/13.0/ce -f values-no-disablepvc.yaml | grep -A 10 "kind: PersistentVolumeClaim"
```

Result:
```yaml
kind: PersistentVolumeClaim
metadata:
  name: seafile-data
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
```

## Test Case 2: disablePVC: false
Expected: PVC created with custom 20Gi storage ✅

```bash
helm template seafile template/13.0/ce -f values-disablepvc-false.yaml | grep -A 10 "kind: PersistentVolumeClaim"
```

Result:
```yaml
kind: PersistentVolumeClaim
metadata:
  name: seafile-data
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 20Gi
```

## Test Case 3: disablePVC: true
Expected: NO PVC created ✅

```bash
helm template seafile template/13.0/ce -f values-disablepvc-true.yaml | grep "kind: PersistentVolumeClaim"
# No output - PVC correctly not created
```

# Test Values Files

Sample values files used for testing are available in the issue description.
